### PR TITLE
Error handling for deferred interaction replies

### DIFF
--- a/index.js
+++ b/index.js
@@ -136,7 +136,7 @@ client.on('interactionCreate', async interaction => {
 		await command.callButton(interaction, Config, client);
 	} catch (error) {
 		console.error(error);
-		if (!interaction.deferred()){
+		if (!interaction.deferred){
             await interaction.deferReply()
         }
         await interaction.editReply('There was an error while executing this command!');

--- a/index.js
+++ b/index.js
@@ -136,7 +136,10 @@ client.on('interactionCreate', async interaction => {
 		await command.callButton(interaction, Config, client);
 	} catch (error) {
 		console.error(error);
-		await interaction.reply({ content: 'There was an error while executing this command!', ephemeral: true });
+		if (!interaction.deferred()){
+            await interaction.deferReply()
+        }
+        await interaction.editReply('There was an error while executing this command!');
 	}
 });
 


### PR DESCRIPTION
When an uncaught error occurs in a command with a deferred reply, the current error handler would cause a complete crash for trying to reply to an interaction that had already been deferred. This checks to see if the reply is deferred, defers it if it isn't and then edits the deferred reply.

Since there's no minimum time to edit a deferred reply, this is suitable for use in all error cases.

This was picked over having multiple cases for both deferred and non-deferred replies to save on lines.